### PR TITLE
HIPP-2007: API Number migration

### DIFF
--- a/app/uk/gov/hmrc/integrationcatalogue/models/ApiDetailSummary.scala
+++ b/app/uk/gov/hmrc/integrationcatalogue/models/ApiDetailSummary.scala
@@ -16,10 +16,15 @@
 
 package uk.gov.hmrc.integrationcatalogue.models
 
-import play.api.libs.json.{Format, Json}
+import org.bson.types.ObjectId
+import play.api.libs.json.{Format, JsObject, Json, OWrites, Reads, Writes}
 import uk.gov.hmrc.integrationcatalogue.models.common.{ApiGeneration, ApiType, IntegrationId, PlatformType}
+import uk.gov.hmrc.mongo.play.json.formats.MongoFormats.Implicits.objectIdFormat
+
+import java.time.Instant
 
 case class ApiDetailSummary(
+  _id: ObjectId = new ObjectId,
   id: IntegrationId,
   publisherReference: String,
   title: String,
@@ -33,12 +38,19 @@ case class ApiDetailSummary(
   teamId: Option[String],
   apiNumber: Option[String],
   apiGeneration: Option[ApiGeneration]
-)
+) {
+
+  def created: Instant = {
+    Instant.ofEpochSecond(_id.getTimestamp)
+  }
+
+}
 
 object ApiDetailSummary {
 
   def apply(apiDetail: ApiDetail): ApiDetailSummary = {
     ApiDetailSummary(
+      _id = apiDetail._id,
       id = apiDetail.id,
       publisherReference = apiDetail.publisherReference,
       title = apiDetail.title,
@@ -55,6 +67,16 @@ object ApiDetailSummary {
     )
   }
 
-  implicit val formatApiDetailSummary: Format[ApiDetailSummary] = Json.format[ApiDetailSummary]
+  private val readsApiDetailSummary: Reads[ApiDetailSummary] = Json.reads[ApiDetailSummary]
+
+  private val writeApiDetailSummary: Writes[ApiDetailSummary] = new OWrites[ApiDetailSummary] {
+    private val oWritesApiDetailSummary = Json.writes[ApiDetailSummary]
+
+    override def writes(apiDetailSummary: ApiDetailSummary): JsObject = {
+      oWritesApiDetailSummary.writes(apiDetailSummary) + ("created", Json.toJson(apiDetailSummary.created)) - "_id"
+    }
+  }
+
+  implicit val formatApiDetailSummary: Format[ApiDetailSummary] = Format(readsApiDetailSummary, writeApiDetailSummary)
 
 }

--- a/app/uk/gov/hmrc/integrationcatalogue/mongojobs/ApiNumberGenerationJob.scala
+++ b/app/uk/gov/hmrc/integrationcatalogue/mongojobs/ApiNumberGenerationJob.scala
@@ -1,0 +1,124 @@
+/*
+ * Copyright 2025 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package uk.gov.hmrc.integrationcatalogue.mongojobs
+
+import com.google.inject.{Inject, Singleton}
+import play.api.Logging
+import uk.gov.hmrc.integrationcatalogue.models.{ApiDetail, ApiDetailSummary}
+import uk.gov.hmrc.integrationcatalogue.repository.{ApiDetailSummaryRepository, IntegrationRepository}
+import uk.gov.hmrc.integrationcatalogue.utils.ApiNumberGenerator
+
+import scala.concurrent.{ExecutionContext, Future}
+import scala.util.{Failure, Success}
+
+@Singleton
+class ApiNumberGenerationJob @Inject()(
+  summaryRepository: ApiDetailSummaryRepository,
+  integrationRepository: IntegrationRepository,
+  apiNumberGenerator: ApiNumberGenerator
+)(implicit ec: ExecutionContext) extends MongoJob with Logging {
+
+  import ApiNumberGenerationJob.*
+
+  override def run(): Future[Unit] = {
+    processApis().map(_ => ())
+  }
+
+  def processApis(): Future[MigrationSummary] = {
+    summaryRepository.findWithFilters(searchTerms = List.empty, platformTypes = List.empty)
+      .map(_.sortBy(_.created))
+      .map(_.map(processApi))
+      .flatMap(Future.sequence(_))
+      .map(
+        _.foldRight(MigrationSummary())((result, summary) => summary.add(result))
+      )
+      .andThen {
+        case Success(summary) =>
+          logger.info(s"API number generation migration complete: summary=${summary.report}")
+        case Failure(e) =>
+          logger.error("API number generation migration failed", e)
+      }
+  }
+
+  private def processApi(api: ApiDetailSummary): Future[MigrationResult] = {
+    apiNumberGenerator.generate(api.platform, api.apiNumber).flatMap {
+      case Some(apiNumber) if !api.apiNumber.contains(apiNumber) => updateApi(api, apiNumber)
+      case Some(_) => Future.successful(HasApiNumber)
+      case None => Future.successful(NoRule)
+    }
+  }
+
+  private def updateApi(api: ApiDetailSummary, apiNumber: String): Future[MigrationResult] = {
+    integrationRepository.findByPublisherRef(api.platform, api.publisherReference).flatMap {
+      case Some(apiDetail: ApiDetail) =>
+        integrationRepository
+          .findAndModify(apiDetail.copy(apiNumber = Some(apiNumber)))
+          .map {
+            case Right(_) => ApiNumberUpdated
+            case Left(e) =>
+              logger.error(s"Error updating API ${apiDetail.id}", e)
+              UpdateError
+          }
+      case _ =>
+        logger.error(s"Cannot find API ${api.id}")
+        Future.successful(UpdateError)
+    }
+  }
+
+}
+
+object ApiNumberGenerationJob {
+
+  sealed trait MigrationResult
+
+  private case object NoRule extends MigrationResult
+  private case object HasApiNumber extends MigrationResult
+  private case object ApiNumberUpdated extends MigrationResult
+  private case object UpdateError extends MigrationResult
+
+  case class MigrationSummary(apis: Int, hasApiNumber: Int, updated: Int, error: Int) {
+
+    def add(migrationResult: MigrationResult): MigrationSummary = {
+      migrationResult match {
+        case NoRule => copy(apis = apis + 1)
+        case HasApiNumber => copy(apis = apis + 1, hasApiNumber = hasApiNumber + 1)
+        case ApiNumberUpdated => copy(apis = apis + 1, updated = updated + 1)
+        case UpdateError => copy(apis = apis + 1, error = error + 1)
+      }
+    }
+
+    def report: String = {
+      Seq(
+        s"apis: $apis",
+        s"noRule: ${apis - hasApiNumber - updated - error}",
+        s"hasApiNumber: $hasApiNumber",
+        s"updated: $updated",
+        s"error: $error"
+      ).mkString(", ")
+    }
+
+  }
+
+  object MigrationSummary {
+
+    def apply(): MigrationSummary = {
+      MigrationSummary(0, 0, 0, 0)
+    }
+
+  }
+
+}

--- a/project/AppDependencies.scala
+++ b/project/AppDependencies.scala
@@ -4,7 +4,7 @@ object AppDependencies {
 
   lazy val scalaCheckVersion = "1.14.0"
   lazy val enumeratumVersion = "1.8.0"
-  lazy val hmrcMongoVersion = "2.5.0"
+  lazy val hmrcMongoVersion = "2.6.0"
   lazy val bootstrapVersion = "9.11.0"
   lazy val jacksonVersion = "2.17.1"
   lazy val playJsonVersion = "2.10.5"

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=1.9.9
+sbt.version=1.10.10

--- a/test/uk/gov/hmrc/integrationcatalogue/mongojobs/ApiNumberGenerationJobSpec.scala
+++ b/test/uk/gov/hmrc/integrationcatalogue/mongojobs/ApiNumberGenerationJobSpec.scala
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2025 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package uk.gov.hmrc.integrationcatalogue.mongojobs
 
 import org.mockito.ArgumentMatchers.{any, eq as eqTo}

--- a/test/uk/gov/hmrc/integrationcatalogue/mongojobs/ApiNumberGenerationJobSpec.scala
+++ b/test/uk/gov/hmrc/integrationcatalogue/mongojobs/ApiNumberGenerationJobSpec.scala
@@ -38,6 +38,18 @@ class ApiNumberGenerationJobSpec extends AsyncFreeSpec with Matchers with Mockit
   import ApiNumberGenerationJobSpec.*
 
   "ApiNumberGenerationJob" - {
+    "musr ru ncorretcly when called from the main entry point" in {
+      val fixture = buildFixture()
+
+      when(fixture.summaryRepository.findWithFilters(any, any))
+        .thenReturn(Future.successful(List.empty))
+
+      fixture.job.run().map {
+        result =>
+          result mustBe ()
+      }
+    }
+
     "must process an empty list of APIs and return the correct summary" in {
       val fixture = buildFixture()
 

--- a/test/uk/gov/hmrc/integrationcatalogue/mongojobs/ApiNumberGenerationJobSpec.scala
+++ b/test/uk/gov/hmrc/integrationcatalogue/mongojobs/ApiNumberGenerationJobSpec.scala
@@ -38,7 +38,7 @@ class ApiNumberGenerationJobSpec extends AsyncFreeSpec with Matchers with Mockit
   import ApiNumberGenerationJobSpec.*
 
   "ApiNumberGenerationJob" - {
-    "musr ru ncorretcly when called from the main entry point" in {
+    "must run correctly when called from the main entry point" in {
       val fixture = buildFixture()
 
       when(fixture.summaryRepository.findWithFilters(any, any))

--- a/test/uk/gov/hmrc/integrationcatalogue/mongojobs/ApiNumberGenerationJobSpec.scala
+++ b/test/uk/gov/hmrc/integrationcatalogue/mongojobs/ApiNumberGenerationJobSpec.scala
@@ -1,0 +1,147 @@
+package uk.gov.hmrc.integrationcatalogue.mongojobs
+
+import org.mockito.ArgumentMatchers.{any, eq as eqTo}
+import org.mockito.Mockito.when
+import org.scalatest.freespec.AsyncFreeSpec
+import org.scalatest.matchers.must.Matchers
+import org.scalatestplus.mockito.MockitoSugar
+import uk.gov.hmrc.integrationcatalogue.models.ApiStatus.LIVE
+import uk.gov.hmrc.integrationcatalogue.models.common.PlatformType.{CDS_CLASSIC, HIP}
+import uk.gov.hmrc.integrationcatalogue.models.common.{IntegrationId, Maintainer, PlatformType, SpecificationType}
+import uk.gov.hmrc.integrationcatalogue.models.{ApiDetail, ApiDetailSummary}
+import uk.gov.hmrc.integrationcatalogue.mongojobs.ApiNumberGenerationJob.MigrationSummary
+import uk.gov.hmrc.integrationcatalogue.repository.{ApiDetailSummaryRepository, IntegrationRepository}
+import uk.gov.hmrc.integrationcatalogue.utils.ApiNumberGenerator
+
+import java.time.Instant
+import java.util.UUID
+import scala.concurrent.Future
+
+class ApiNumberGenerationJobSpec extends AsyncFreeSpec with Matchers with MockitoSugar {
+
+  import ApiNumberGenerationJobSpec.*
+
+  "ApiNumberGenerationJob" - {
+    "must process an empty list of APIs and return the correct summary" in {
+      val fixture = buildFixture()
+
+      when(fixture.summaryRepository.findWithFilters(any, any))
+        .thenReturn(Future.successful(List.empty))
+
+      fixture.job.processApis().map {
+        result =>
+          result mustBe MigrationSummary()
+      }
+    }
+
+    "must process a non-empty list of APIs correctly" in {
+      val fixture = buildFixture()
+      val nextApiNumber = "API#101"
+
+      when(fixture.summaryRepository.findWithFilters(any, any))
+        .thenReturn(Future.successful(
+          List(
+            ApiDetailSummary(noRuleApi),
+            ApiDetailSummary(hasApiNumberApi),
+            ApiDetailSummary(updatedApi),
+            ApiDetailSummary(updateErrorApi)
+          )))
+
+      // General stubs
+      when(fixture.apiNumberGenerator.generate(eqTo(HIP), eqTo(None)))
+        .thenReturn(Future.successful(Some(nextApiNumber)))
+
+      // Stubs for an API that has no platform rule
+      when(fixture.apiNumberGenerator.generate(eqTo(noRuleApi.platform), any))
+        .thenReturn(Future.successful(None))
+
+      // Stubs for a HIP API that already has an API number
+      when(fixture.apiNumberGenerator.generate(eqTo(HIP), eqTo(hasApiNumberApi.apiNumber)))
+        .thenReturn(Future.successful(hasApiNumberApi.apiNumber))
+
+      // Stubs for an API that gets updated
+      when(fixture.integrationRepository.findByPublisherRef(eqTo(HIP), eqTo(updatedApi.publisherReference)))
+        .thenReturn(Future.successful(Some(updatedApi)))
+
+      when(fixture.integrationRepository.findByPublisherRef(eqTo(HIP), eqTo(updatedApi.publisherReference)))
+        .thenReturn(Future.successful(Some(updatedApi)))
+
+      val updateApiWithNumber = updatedApi.copy(apiNumber = Some(nextApiNumber))
+
+      when(fixture.integrationRepository.findAndModify(eqTo(updateApiWithNumber)))
+        .thenReturn(Future.successful(Right((updateApiWithNumber, true))))
+
+      // Stubs for an API that results in update error
+      when(fixture.integrationRepository.findByPublisherRef(eqTo(HIP), eqTo(updateErrorApi.publisherReference)))
+        .thenReturn(Future.successful(Some(updateErrorApi)))
+
+      when(fixture.integrationRepository.findByPublisherRef(eqTo(HIP), eqTo(updateErrorApi.publisherReference)))
+        .thenReturn(Future.successful(Some(updateErrorApi)))
+
+      val updateErrorApiWithNumber= updateErrorApi.copy(apiNumber = Some(nextApiNumber))
+
+      when(fixture.integrationRepository.findAndModify(eqTo(updateErrorApiWithNumber)))
+        .thenReturn(Future.successful(Left(new Exception())))
+
+      fixture.job.processApis().map {
+        result =>
+          result mustBe MigrationSummary(4, 1, 1, 1)
+      }
+    }
+  }
+
+  private def buildFixture(): Fixture = {
+    val summaryRepository = mock[ApiDetailSummaryRepository]
+    val integrationRepository = mock[IntegrationRepository]
+    val apiNumberGenerator = mock[ApiNumberGenerator]
+
+    val job = new ApiNumberGenerationJob(
+      summaryRepository,
+      integrationRepository,
+      apiNumberGenerator
+    )
+
+    Fixture(
+      summaryRepository,
+      integrationRepository,
+      apiNumberGenerator,
+      job
+    )
+  }
+
+}
+
+private object ApiNumberGenerationJobSpec {
+
+  private def buildApi(index: Int, platform: PlatformType, apiNumber: Option[String] = None) = ApiDetail(
+    id = IntegrationId(UUID.randomUUID()),
+    publisherReference = s"test-publisher-ref-$index",
+    title = s"test-title-$index",
+    description = s"test-description-$index",
+    lastUpdated = Instant.now(),
+    platform = platform,
+    maintainer = Maintainer(name = "test-maintainer", slackChannel = "test-slack-channel", contactInfo = List.empty),
+    version = "1.0.0",
+    specificationType = SpecificationType.OAS_V3,
+    endpoints = List.empty,
+    shortDescription = None,
+    openApiSpecification = s"test-oas-$index",
+    apiStatus = LIVE,
+    reviewedDate = Instant.now(),
+    scopes = Set.empty,
+    apiNumber = apiNumber
+  )
+
+  val noRuleApi: ApiDetail = buildApi(1, CDS_CLASSIC)
+  val hasApiNumberApi: ApiDetail = buildApi(2, HIP, Some("API#2"))
+  val updatedApi: ApiDetail = buildApi(3, HIP)
+  val updateErrorApi: ApiDetail = buildApi(4, HIP)
+
+  case class Fixture(
+    summaryRepository: ApiDetailSummaryRepository,
+    integrationRepository: IntegrationRepository,
+    apiNumberGenerator: ApiNumberGenerator,
+    job: ApiNumberGenerationJob
+  )
+
+}


### PR DESCRIPTION
https://jira.tools.tax.service.gov.uk/browse/HIPP-2007

Also added the created date derived attribute to ApiDetailSummary as per ApiDetail. This allows the migration to use the smaller model type, fetch all data, and order all APIs by created date.